### PR TITLE
Release 5 3 learning progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Stefan Meyer - meyer AT leifos.com
 German, English
 
 **Related Plugins:**
-ViteroSingleLogout
+ViteroSingleLogout, ViteroLPCron 
 
 **Bug Tracker:**
 [ILIAS MantisBT](http://www.ilias.de/mantis/search.php?project_id=3&category=Vitero)

--- a/classes/class.ilObjVitero.php
+++ b/classes/class.ilObjVitero.php
@@ -30,7 +30,7 @@ include_once("./Services/Repository/classes/class.ilObjectPlugin.php");
 *
 * $Id: class.ilObjVitero.php 56608 2014-12-19 10:11:57Z fwolf $
 */
-class ilObjVitero extends ilObjectPlugin
+class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 {
 	const MEMBER = 1;
 	const ADMIN = 2;
@@ -704,6 +704,72 @@ class ilObjVitero extends ilObjectPlugin
 		}
 
 		return $total_appointments;
+	}
+
+	/**
+	 * Get all user ids with LP status completed
+	 *
+	 * @return array
+	 */
+	public function getLPCompleted()
+	{
+		//TODO: NO CALCULATIONS, NO SOAP request etc.. here. ONLY queries to ILIAS DB
+
+		return array();
+	}
+
+	/**
+	 * Get all user ids with LP status not attempted
+	 *
+	 * @return array
+	 */
+	public function getLPNotAttempted()
+	{
+		//TODO: NO CALCULATIONS, NO SOAP request etc.. here. ONLY queries to ILIAS DB
+
+		return array();
+	}
+
+	/**
+	 * Get all user ids with LP status failed
+	 *
+	 * @return array
+	 */
+	public function getLPFailed()
+	{
+		//TODO: NO CALCULATIONS, NO SOAP request etc.. here. ONLY queries to ILIAS DB
+
+		return array();
+	}
+
+	/**
+	 * Get all user ids with LP status in progress
+	 *
+	 * @return array
+	 */
+	public function getLPInProgress()
+	{
+		//TODO: NO CALCULATIONS, NO SOAP request etc.. here. ONLY queries to ILIAS DB
+
+		return array();
+	}
+
+	/**
+	 * Get current status for given user
+	 *
+	 * @param int $a_user_id
+	 * @return int
+	 */
+	public function getLPStatusForUser($a_user_id)
+	{
+		//TODO: NO CALCULATIONS, NO SOAP request etc.. here. ONLY queries to ILIAS DB
+
+		//Will return one of these status:
+		//  const LP_STATUS_NOT_ATTEMPTED_NUM = 0;
+		//	const LP_STATUS_IN_PROGRESS_NUM = 1;
+		//	const LP_STATUS_COMPLETED_NUM = 2;
+		//	const LP_STATUS_FAILED_NUM = 3;
+		return ilLPStatus::LP_STATUS_COMPLETED_NUM;
 	}
 }
 ?>

--- a/classes/class.ilObjVitero.php
+++ b/classes/class.ilObjVitero.php
@@ -558,7 +558,7 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 	}
 
 	//TODO isLearningProgressActive will be better when consume this class
-	public function getLearningProgress()
+	public function isLearningProgressActive()
 	{
 		return $this->learning_progress;
 	}
@@ -610,7 +610,7 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 		global $ilDB;
 
 		$query = "UPDATE rep_robj_xvit_lp SET" .
-			" active = " . $ilDB->quote($this->getLearningProgress(), "integer") . ", " .
+			" active = " . $ilDB->quote($this->isLearningProgressActive(), "integer") . ", " .
 			" min_percent = " . $ilDB->quote($this->getLearningProgressMinPercentage(), "integer") . ", " .
 			" mode_multi = " . $ilDB->quote($this->getLearningProgressModeMulti(), "integer") . ", " .
 			" min_sessions = " . $ilDB->quote($this->getLearningProgressMinSessions(), "integer") .
@@ -626,7 +626,7 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 		$query = "INSERT INTO rep_robj_xvit_lp (obj_id,active,min_percent,mode_multi,min_sessions)" .
 			" VALUES(" .
 			$ilDB->quote($this->getId(), "integer") . ", " .
-			$ilDB->quote($this->getLearningProgress(), "integer") . ", " .
+			$ilDB->quote($this->isLearningProgressActive(), "integer") . ", " .
 			$ilDB->quote($this->getLearningProgressMinPercentage(), "integer") . ", " .
 			$ilDB->quote($this->getLearningProgressModeMulti(), "integer") . ", " .
 			$ilDB->quote($this->getLearningProgressMinSessions(), "integer") .

--- a/classes/class.ilObjVitero.php
+++ b/classes/class.ilObjVitero.php
@@ -721,9 +721,9 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 		$min_sessions_passed = $this->getLearningProgressMinSessions();
 
 		$sql = "SELECT user_id," .
-			" COUNT( CASE WHEN percentage >= " .$min_percent. " THEN 1 END) count_passed" .
+			" COUNT( CASE WHEN percentage >= " .$this->db->quote($min_percent, "integer"). " THEN 1 END) count_passed" .
 			" FROM rep_robj_xvit_recs" .
-			" WHERE obj_id = " . $this->getId() .
+			" WHERE obj_id = " . $this->db->quote($this->getId(), "integer") .
 			" GROUP BY user_id";
 
 		$res = $db->query($sql);
@@ -781,9 +781,9 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 		$min_sessions_passed = $this->getLearningProgressMinSessions();
 
 		$sql = "SELECT user_id," .
-			" COUNT( CASE WHEN percentage > " .$min_percent. " THEN 1 END) count_passed" .
+			" COUNT( CASE WHEN percentage > " .$this->db->quote($min_percent, "integer"). " THEN 1 END) count_passed" .
 			" FROM rep_robj_xvit_recs" .
-			" WHERE obj_id = " . $this->getId() .
+			" WHERE obj_id = " . $this->db->quote($this->getId(), "integer") .
 			" GROUP BY user_id";
 
 		$res = $db->query($sql);
@@ -833,7 +833,7 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 
 		$sql = "SELECT user_id" .
 			" FROM rep_robj_xvit_recs" .
-			" WHERE obj_id = " . $this->getId() .
+			" WHERE obj_id = " . $this->db->quote($this->getId(), "integer") .
 			" GROUP BY user_id";
 
 		$res = $db->query($sql);

--- a/classes/class.ilObjVitero.php
+++ b/classes/class.ilObjVitero.php
@@ -595,12 +595,13 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 
 	public function saveLearningProgressData()
 	{
-		if($this->is_learning_progress_stored)
-		{
-			return $this->updateLearningProgress();
+		if($this->is_learning_progress_stored) {
+			$this->updateLearningProgress();
+		} else {
+			$this->insertLearningProgress();
 		}
 
-		return $this->insertLearningProgress();
+		ilLPStatusWrapper::_refreshStatus($this->getId());
 	}
 
 	protected function updateLearningProgress()

--- a/classes/class.ilObjVitero.php
+++ b/classes/class.ilObjVitero.php
@@ -729,12 +729,11 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 			" WHERE obj_id = " . $this->getId() .
 			" GROUP BY user_id";
 
-		ilLoggerFactory::getRootLogger()->debug("Query => ".$sql);
-
 		$res = $db->query($sql);
 
 		$users_completed = array();
-		while($row = $db->fetchAll($res))
+
+		while($row = $db->fetchAssoc($res))
 		{
 			if($row['count_passed'] >= $min_sessions_passed)
 			{
@@ -742,7 +741,6 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 			}
 		}
 
-		ilLoggerFactory::getRootLogger()->dump($users_completed);
 		return $users_completed;
 	}
 
@@ -787,6 +785,7 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 		global $DIC;
 
 		$db = $DIC->database();
+
 		$this->readLearningProgressSettings();
 
 		$min_percent = $this->getLearningProgressMinPercentage();
@@ -798,25 +797,21 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 			" WHERE obj_id = " . $this->getId() .
 			" GROUP BY user_id";
 
-		ilLoggerFactory::getRootLogger()->debug("Query => ".$sql);
-
 		$res = $db->query($sql);
 
-		$users_completed = array();
-		while($row = $db->fetchAll($res))
+		$users_in_progress = array();
+		while($row = $db->fetchAssoc($res))
 		{
-			if($row['count_passed'] < $min_sessions_passed || 1==1)
+			if($row['count_passed'] < $min_sessions_passed)
 			{
-				array_push($users_completed, $row['user_id']);
+				array_push($users_in_progress, $row['user_id']);
 			}
 		}
 
-		ilLoggerFactory::getRootLogger()->dump($users_completed);
-		return $users_completed;
+		return $users_in_progress;
 	}
 
 	/**
-	 * TODO: Is this the best way?
 	 * Get current status for given user
 	 *
 	 * @param int $a_user_id

--- a/classes/class.ilObjVitero.php
+++ b/classes/class.ilObjVitero.php
@@ -850,5 +850,17 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 		return $users_attempted;
 	}
 
+	public function isLearningProgressAvailable()
+	{
+		if(ilLearningProgressAccess::checkAccess($this->getRefId())
+			&& ilViteroSettings::getInstance()->isLearningProgressEnabled()
+			&& ilViteroUtils::hasCustomerMonitoringMode())
+		{
+			return true;
+		}
+
+		return false;
+	}
+
 }
 ?>

--- a/classes/class.ilObjVitero.php
+++ b/classes/class.ilObjVitero.php
@@ -554,6 +554,7 @@ class ilObjVitero extends ilObjectPlugin
 		$this->learning_progress = (bool)$learning_progress;
 	}
 
+	//TODO isLearningProgressActive will be better when consume this class
 	public function getLearningProgress()
 	{
 		return $this->learning_progress;
@@ -574,6 +575,7 @@ class ilObjVitero extends ilObjectPlugin
 		$this->learning_progress_mode_multi = (bool)$is_multi;
 	}
 
+	//TODO isLearningProgressModeMulti will be better when consume this class
 	public function getLearningProgressModeMulti()
 	{
 		return $this->learning_progress_mode_multi;

--- a/classes/class.ilObjVitero.php
+++ b/classes/class.ilObjVitero.php
@@ -24,8 +24,7 @@
 include_once("./Services/Repository/classes/class.ilObjectPlugin.php");
 
 /**
- * TODO centralize the load of lp settings readLearningProgressSettings
- * TODO DRY for the Query getLPInProgress getLTCompleted etc... 99% duplicated
+ * TODO(Next patch will fix this) DRY for the Query getLPInProgress getLTCompleted etc... 99% duplicated
 * Application class for vitero repository object.
 *
 * @author Stefan Meyer <smeyer.ilias@gmx.de>
@@ -557,7 +556,6 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 		$this->learning_progress = (bool)$learning_progress;
 	}
 
-	//TODO isLearningProgressActive will be better when consume this class
 	public function isLearningProgressActive()
 	{
 		return $this->learning_progress;
@@ -578,8 +576,7 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 		$this->learning_progress_mode_multi = (bool)$is_multi;
 	}
 
-	//TODO isLearningProgressModeMulti will be better when consume this class
-	public function getLearningProgressModeMulti()
+	public function isLearningProgressModeMultiActive()
 	{
 		return $this->learning_progress_mode_multi;
 	}
@@ -612,7 +609,7 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 		$query = "UPDATE rep_robj_xvit_lp SET" .
 			" active = " . $ilDB->quote($this->isLearningProgressActive(), "integer") . ", " .
 			" min_percent = " . $ilDB->quote($this->getLearningProgressMinPercentage(), "integer") . ", " .
-			" mode_multi = " . $ilDB->quote($this->getLearningProgressModeMulti(), "integer") . ", " .
+			" mode_multi = " . $ilDB->quote($this->isLearningProgressModeMultiActive(), "integer") . ", " .
 			" min_sessions = " . $ilDB->quote($this->getLearningProgressMinSessions(), "integer") .
 			" WHERE obj_id = ".$ilDB->quote($this->getId(), "integer");
 
@@ -628,7 +625,7 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 			$ilDB->quote($this->getId(), "integer") . ", " .
 			$ilDB->quote($this->isLearningProgressActive(), "integer") . ", " .
 			$ilDB->quote($this->getLearningProgressMinPercentage(), "integer") . ", " .
-			$ilDB->quote($this->getLearningProgressModeMulti(), "integer") . ", " .
+			$ilDB->quote($this->isLearningProgressModeMultiActive(), "integer") . ", " .
 			$ilDB->quote($this->getLearningProgressMinSessions(), "integer") .
 			")";
 

--- a/classes/class.ilObjVitero.php
+++ b/classes/class.ilObjVitero.php
@@ -551,6 +551,7 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 		return 0;
 	}
 
+	//LEARNING PROGRESS SETTINGS
 	public function setLearningProgress($learning_progress)
 	{
 		$this->learning_progress = (bool)$learning_progress;
@@ -751,6 +752,7 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 	public function getLPNotAttempted()
 	{
 		//TODO members added but never entered in the vitero session
+		// compare members list with lp list (getUsersAttempted)
 		return array();
 	}
 
@@ -809,12 +811,43 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 	 */
 	public function getLPStatusForUser($a_user_id)
 	{
-		if(ilLPStatus::_hasUserCompleted($this->getId(), $a_user_id))
+		if(in_array($a_user_id, $this->getUsersAttempted()))
 		{
-			return ilLPStatus::LP_STATUS_COMPLETED_NUM;
+			if(ilLPStatus::_hasUserCompleted($this->getId(), $a_user_id))
+			{
+				return ilLPStatus::LP_STATUS_COMPLETED_NUM;
+			}
+
+			return ilLPStatus::LP_STATUS_IN_PROGRESS_NUM;
 		}
 
-		return ilLPStatus::LP_STATUS_IN_PROGRESS_NUM;
+		return ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM;
+	}
+
+	/**
+	 * Get users ids of the current vitero object.
+	 * @return array
+	 */
+	protected function getUsersAttempted()
+	{
+		global $DIC;
+
+		$db = $DIC->database();
+
+		$sql = "SELECT user_id" .
+			" FROM rep_robj_xvit_recs" .
+			" WHERE obj_id = " . $this->getId() .
+			" GROUP BY user_id";
+
+		$res = $db->query($sql);
+
+		$users_attempted = array();
+		while($row = $db->fetchAssoc($res))
+		{
+			array_push($users_attempted, $row['user_id']);
+		}
+
+		return $users_attempted;
 	}
 
 }

--- a/classes/class.ilObjVitero.php
+++ b/classes/class.ilObjVitero.php
@@ -663,9 +663,7 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 	{
 		$this->is_learning_progress_stored = true;
 	}
-
-	//groups here = teams in vitero website
-
+	
 	/**
 	 * @return int total number of appointments.
 	 * @throws ilDateTimeException
@@ -752,15 +750,7 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 	 */
 	public function getLPNotAttempted()
 	{
-
-		/*global $DIC;
-
-		$review = $DIC->rbac()->review();
-
-		return $review->assignedUsers($this->getDefaultMemberRole());*/
-
-		//TODO: NO CALCULATIONS, NO SOAP request etc.. here. ONLY queries to ILIAS DB
-
+		//TODO members added but never entered in the vitero session
 		return array();
 	}
 
@@ -771,8 +761,7 @@ class ilObjVitero extends ilObjectPlugin implements ilLPStatusPluginInterface
 	 */
 	public function getLPFailed()
 	{
-		//TODO: NO CALCULATIONS, NO SOAP request etc.. here. ONLY queries to ILIAS DB
-
+		//nothing to do here.
 		return array();
 	}
 

--- a/classes/class.ilObjVitero.php
+++ b/classes/class.ilObjVitero.php
@@ -658,5 +658,50 @@ class ilObjVitero extends ilObjectPlugin
 	{
 		$this->is_learning_progress_stored = true;
 	}
+
+	//groups here = teams in vitero website
+
+	/**
+	 * @return int total number of appointments.
+	 * @throws ilDateTimeException
+	 */
+	public function getNumberOfAppointmentsForSession()
+	{
+		$start = new ilDateTime(time(),IL_CAL_UNIX);
+		$end = clone $start;
+		$start->increment(IL_CAL_YEAR,-5);
+		$end->increment(IL_CAL_YEAR,1);
+
+		$vitero_group_id = $this->getVGroupId();
+
+		try {
+			$con = new ilViteroBookingSoapConnector();
+			$bookings = $con->getByGroupAndDate($vitero_group_id, $start, $end);
+		}
+		catch(Exception $e) {
+			throw $e;
+		}
+
+		$booking_arr = array();
+		if(is_object($bookings->booking))
+		{
+			$booking_arr = array($bookings->booking);
+		}
+		elseif(is_array($bookings->booking))
+		{
+			$booking_arr = $bookings->booking;
+		}
+
+		$total_appointments = 0;
+		foreach($booking_arr as $booking)
+		{
+			//one booking can contain more than one appointment
+			foreach (ilViteroUtils::calculateBookingAppointments($start, $end, $booking) as $dl) {
+				$total_appointments++;
+			}
+		}
+
+		return $total_appointments;
+	}
 }
 ?>

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -51,25 +51,6 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 	 */
 	private $vitero_logger = null;
 
-	//TODO: test this override
-	/*function executeCommand()
-	{
-		if($this->ctrl->getNextClass($this) == 'illearningprogressgui')
-		{
-			$ilTabs->setTabActive("learning_progress");
-				$new_gui = new ilLearningProgressGUI(ilLearningProgressGUI::LP_CONTEXT_REPOSITORY,
-													$this->object->getRefId(),
-													$_GET['user_id'] ? $_GET['user_id'] : $GLOBALS['ilUser']->getId());
-				$new_gui->addRefreshLPStatusButton();
-				}
-
-				$this->ctrl->setParameterByClass("illearningprogressgui",'ref_lp_btn', 1);
-				$this->ctrl->forwardCommand($new_gui);
-		}
-
-		parent::executeCommand();
-	}*/
-
 	/**
 	* Initialisation
 	*/
@@ -724,7 +705,6 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 	 */
 	protected function syncLearningProgress()
 	{
-		global $ilTabs, $tpl;
 		$vitero_group_id = (int)$this->object->getVGroupId();
 
 		$vitero_learning_progress = new ilViteroLearningProgress();

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -41,7 +41,7 @@ include_once("./Services/Repository/classes/class.ilObjectPluginGUI.php");
 *
 * @ilCtrl_isCalledBy ilObjViteroGUI: ilRepositoryGUI, ilAdministrationGUI, ilObjPluginDispatchGUI
 * @ilCtrl_Calls ilObjViteroGUI: ilPermissionGUI, ilInfoScreenGUI, ilObjectCopyGUI, ilRepositorySearchGUI
-* @ilCtrl_Calls ilObjViteroGUI: ilCommonActionDispatcherGUI
+* @ilCtrl_Calls ilObjViteroGUI: ilCommonActionDispatcherGUI, ilLearningProgressGUI
 *
 */
 class ilObjViteroGUI extends ilObjectPluginGUI
@@ -666,6 +666,14 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 			);
 		}
 
+		include_once './Services/Tracking/classes/class.ilLearningProgressAccess.php';
+		if(ilLearningProgressAccess::checkAccess($this->object->getRefId()))
+		{
+			$ilTabs->addTab(
+				'learning_progress',
+				$this->txt('learning_progress'),
+				$ilCtrl->getLinkTargetByClass('illearningprogressgui',''));
+		}
 
 		// standard epermission tab
 		$this->addPermissionTab();

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -847,7 +847,7 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 			);
 
 			//TODO rename this method to avoid if negate
-			if(!$this->canCreateAppointmentsByLearningProgressMode())
+			if($this->canNOTCreateAppointmentsByLearningProgressMode())
 			{
 				$add_app_button = $add_app_button->withUnavailableAction();
 				$ilToolbar->addComponent($add_app_button);
@@ -2033,7 +2033,7 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 	 * Returns false if learning progress has mode "one session" and we have an appointment already
 	 * @return bool
 	 */
-	public function canCreateAppointmentsByLearningProgressMode()
+	public function canNotCreateAppointmentsByLearningProgressMode()
 	{
 		if($this->object->getLearningProgress()) {
 			$total_appointments = $this->object->getNumberOfAppointmentsForSession();

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -868,13 +868,15 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 		$table->init();
 
 		$start = new ilDateTime(time(),IL_CAL_UNIX);
+		$end = clone $start;
 		if($user_has_write_access) {
 			$start->increment(ilDateTime::YEAR,-1);
 		} else {
 			$start->increment(ilDateTime::HOUR,-1);
 		}
-		$end = clone $start;
+
 		$end->increment(IL_CAL_YEAR,1);
+
 		try {
 			$table->parse(
 				$this->object->getVGroupId(),

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -667,7 +667,7 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 		}
 
 		include_once './Services/Tracking/classes/class.ilLearningProgressAccess.php';
-		if(ilLearningProgressAccess::checkAccess($this->object->getRefId()))
+		if(ilLearningProgressAccess::checkAccess($this->object->getRefId()) && $this->object->getLearningProgress())
 		{
 			$ilTabs->addTab(
 				'learning_progress',

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -58,7 +58,9 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 	{
 		$this->vitero_logger = $GLOBALS['DIC']->logger()->xvit();
 
-		$this->object->readLearningProgressSettings();
+		if($this->object) {
+			$this->object->readLearningProgressSettings();
+		}
 
 		// anything needed after object has been constructed
 		// - example: append my_id GET parameter to each request
@@ -838,7 +840,8 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 		$table->setVGroupId($this->object->getVGroupId());
 		$table->setEditable((bool) $ilAccess->checkAccess('write','',$this->object->getRefId()));
 		$table->init();
-		
+
+		//TODO START-END ISSUE
 		$start = new ilDateTime(time(),IL_CAL_UNIX);
 		$start->increment(ilDateTime::HOUR,-1);
 		$end = clone $start;

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -718,15 +718,21 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 		$tpl->setContent($this->form->getHTML());
 	}
 
-	//TODO: Nice to have: sync only the current vitero session.
+	/**
+	 * Sync only 1 vitero group / ilias vitero session.
+	 * @throws ilDateTimeException
+	 */
 	protected function syncLearningProgress()
 	{
+		global $ilTabs, $tpl;
 		$vitero_group_id = (int)$this->object->getVGroupId();
 
 		$vitero_learning_progress = new ilViteroLearningProgress();
 		$vitero_learning_progress->updateLearningProgress($vitero_group_id);
 
-		$this->plugin->updateLearningProgress();
+		ilUtil::sendInfo(ilViteroPlugin::getInstance()->txt('info_msg_session_sinc_success'),true);
+
+		$this->editProperties();
 	}
 
 	protected function addSyncLearningProgressButton()
@@ -740,8 +746,10 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 			ilViteroPlugin::getInstance()->txt('btn_sync_lp'),
 			$this->ctrl->getLinkTarget($this,'syncLearningProgress')
 		);
-		$toolbar->addComponent($btn_refresh_lp);
+
 		$toolbar->addText(ilViteroPlugin::getInstance()->txt("btn_sync_lp_info"));
+
+		$toolbar->addComponent($btn_refresh_lp);
 	}
 	
 	/**

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -897,8 +897,7 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 				$this->ctrl->getLinkTarget($this,'showAppointmentCreation')
 			);
 
-			//TODO rename this method to avoid if negate
-			if($this->canNOTCreateAppointmentsByLearningProgressMode())
+			if($this->canNotCreateAppointmentsByLearningProgressMode())
 			{
 				$add_app_button = $add_app_button->withUnavailableAction();
 				$ilToolbar->addComponent($add_app_button);
@@ -2086,15 +2085,13 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 	 */
 	public function canNotCreateAppointmentsByLearningProgressMode()
 	{
-		if($this->object->getLearningProgress()) {
-			$total_appointments = $this->object->getNumberOfAppointmentsForSession();
-
+		if($this->object->isLearningProgressActive()) {
 			if (!$this->object->getLearningProgressModeMulti() && ($this->object->getNumberOfAppointmentsForSession() >= 1)) {
-				return false;
+				return true;
 			}
 		}
 
-		return true;
+		return false;
 	}
 }
 ?>

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -687,7 +687,7 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 		}
 
 		include_once './Services/Tracking/classes/class.ilLearningProgressAccess.php';
-		if(ilLearningProgressAccess::checkAccess($this->object->getRefId()) && $this->object->getLearningProgress())
+		if(ilLearningProgressAccess::checkAccess($this->object->getRefId()) && $this->object->isLearningProgressActive())
 		{
 			$ilTabs->addTab(
 				'learning_progress',
@@ -707,7 +707,7 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 		global $tpl, $ilTabs;
 
 		// TODO: I keep the individual session sync button here while finding a solution via executeCommand
-		if(ilLearningProgressAccess::checkAccess($this->object->getRefId()) && $this->object->getLearningProgress())
+		if(ilLearningProgressAccess::checkAccess($this->object->getRefId()) && $this->object->isLearningProgressActive())
 		{
 			$this->addSyncLearningProgressButton();
 		}
@@ -833,7 +833,7 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 	{
 		$values["title"] = $this->object->getTitle();
 		$values["desc"] = $this->object->getDescription();
-		$values['learning_progress'] = $this->object->getLearningProgress();
+		$values['learning_progress'] = $this->object->isLearningProgressActive();
 		$values['min_percentage'] = $this->object->getLearningProgressMinPercentage();
 		$values['mode'] = $this->object->getLearningProgressModeMulti();
 		$values['min_sessions'] = $this->object->getLearningProgressMinSessions();
@@ -1595,7 +1595,7 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 	 */
 	protected function controlDeletionByLearningModuleMode($book)
 	{
-		if($this->object->getLearningProgress())
+		if($this->object->isLearningProgressActive())
 		{
 			$total_appointments = $this->object->getNumberOfAppointmentsForSession();
 			$start = new ilDateTime(time(),IL_CAL_UNIX);

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -712,9 +712,25 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 		// description
 		$ta = new ilTextAreaInputGUI($this->txt("description"), "desc");
 		$this->form->addItem($ta);
-		
+
+		//TODO extract this conditional to a method.
+		if(ilLearningProgressAccess::checkAccess($this->object->getRefId())
+			&& ilViteroSettings::getInstance()->isLearningProgressEnabled()
+			&& ilViteroUtils::hasCustomerMonitoringMode())
+		{
+			$pres = new ilFormSectionHeaderGUI();
+			$pres->setTitle($this->lng->txt('edit_learning_progress_properties'));
+			$this->form->addItem($pres);
+
+			//TODO : Implement Appointments check, café mode etc.
+
+			$learning_progress = new ilCheckboxInputGUI($this->lng->txt('activate_learning_progress'), 'learning_progress');
+			$learning_progress->setInfo($this->lng->txt('activate_learning_progress_info'));
+			$this->form->addItem($learning_progress);
+		}
+
 		$this->form->addCommandButton("updateProperties", $this->txt("save"));
-	                
+
 		$this->form->setTitle($this->txt("edit_properties"));
 		$this->form->setFormAction($ilCtrl->getFormAction($this));
 	}

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -50,8 +50,7 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 	 * @var ilLogger
 	 */
 	private $vitero_logger = null;
-	
-	
+
 	/**
 	* Initialisation
 	*/
@@ -506,7 +505,6 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 		return true;
 	}
 
-
 	protected function loadCafeSettings($form,$room)
 	{
 		$room->enableCafe(true);
@@ -603,9 +601,6 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 		$newObj->addParticipants(array($ilUser->getId()), ilObjVitero::ADMIN);
 		parent::afterSave($newObj);
 	}
-
-
-
 
 	/**
 	* After object has been created -> jump to this command
@@ -882,8 +877,6 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 		}
 	}
 
-
-
 	/**
 	 * Add info items
 	 * @param ilInfoScreenGUI $info 
@@ -1093,7 +1086,6 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 			$ilCtrl->redirect($this,'infoScreen');
 		}
 	}
-
 
 	/**
 	 * Show participants
@@ -1348,7 +1340,6 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 		return true;
 	}
 
-
 	/**
 	 * set preferences (show/hide tabel content)
 	 *
@@ -1368,7 +1359,6 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 			$ilUser->writePref('xvit_member_hide',(int) $_GET['member_hide']);
 		}
 	}
-
 
 	protected function addSearchToolbar()
 	{
@@ -1747,7 +1737,6 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 		$form = $this->initUpdateBookingForm($booking);
 		$GLOBALS['tpl']->setContent($form->getHTML());
 	}
-
 
 	/**
 	 * @param $booking

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -810,6 +810,8 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 
 			$this->object->saveLearningProgressData();
 			$this->updateObject();
+			//TODO -> read: with this refresh thing we recalculate everything when update the settings.
+			ilLPStatusWrapper::_refreshStatus($this->object->getId());
 
 			ilUtil::sendSuccess($lng->txt("msg_obj_modified"), true);
 			$ilCtrl->redirect($this, "editProperties");

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -849,7 +849,6 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 		$table->setEditable((bool) $ilAccess->checkAccess('write','',$this->object->getRefId()));
 		$table->init();
 
-		//TODO START-END ISSUE
 		$start = new ilDateTime(time(),IL_CAL_UNIX);
 		$start->increment(ilDateTime::HOUR,-1);
 		$end = clone $start;

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -834,8 +834,10 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 
 		$ilTabs->activateTab("content");
 
+		$user_has_write_access = $ilAccess->checkAccess('write','',$this->object->getRefId());
+
 		// Show add appointment
-		if($ilAccess->checkAccess('write','',$this->object->getRefId()))
+		if($user_has_write_access)
 		{
 			$add_app_button = $ui_factory->button()->standard(
 				ilViteroPlugin::getInstance()->txt('tbbtn_add_appointment'),
@@ -864,7 +866,11 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 		$table->init();
 
 		$start = new ilDateTime(time(),IL_CAL_UNIX);
-		$start->increment(ilDateTime::HOUR,-1);
+		if($user_has_write_access) {
+			$start->increment(ilDateTime::YEAR,-1);
+		} else {
+			$start->increment(ilDateTime::HOUR,-1);
+		}
 		$end = clone $start;
 		$end->increment(IL_CAL_YEAR,1);
 		try {

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -721,6 +721,11 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 	//TODO: Nice to have: sync only the current vitero session.
 	protected function syncLearningProgress()
 	{
+		$vitero_group_id = (int)$this->object->getVGroupId();
+
+		$vitero_learning_progress = new ilViteroLearningProgress();
+		$vitero_learning_progress->updateLearningProgress($vitero_group_id);
+
 		$this->plugin->updateLearningProgress();
 	}
 

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -795,7 +795,7 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 	*/
 	public function updateProperties()
 	{
-		global $tpl, $lng, $ilCtrl;
+		global $tpl, $lng, $ilCtrl, $ilTabs;
 	
 		$this->initPropertiesForm();
 		if ($this->form->checkInput())
@@ -809,13 +809,13 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 			$this->object->setLearningProgressMinSessions($this->form->getInput("min_sessions"));
 
 			$this->object->saveLearningProgressData();
-			$this->updateObject();
-			//TODO -> read: with this refresh thing we recalculate everything when update the settings.
-			ilLPStatusWrapper::_refreshStatus($this->object->getId());
+			$this->object->update();
 
 			ilUtil::sendSuccess($lng->txt("msg_obj_modified"), true);
 			$ilCtrl->redirect($this, "editProperties");
 		}
+
+		$ilTabs->activateTab("properties");
 
 		$this->form->setValuesByPost();
 		$tpl->setContent($this->form->getHtml());

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -700,8 +700,6 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 	public function initPropertiesForm()
 	{
 		global $ilCtrl;
-
-		$vitero_plugin = ilViteroPlugin::getInstance();
 	
 		include_once("Services/Form/classes/class.ilPropertyFormGUI.php");
 		$this->form = new ilPropertyFormGUI();
@@ -714,65 +712,73 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 		// description
 		$ta = new ilTextAreaInputGUI($this->txt("description"), "desc");
 		$this->form->addItem($ta);
-
-		//TODO extract this conditional to a method.
 		if(ilLearningProgressAccess::checkAccess($this->object->getRefId())
 			&& ilViteroSettings::getInstance()->isLearningProgressEnabled()
 			&& ilViteroUtils::hasCustomerMonitoringMode())
 		{
-			$pres = new ilFormSectionHeaderGUI();
-			$pres->setTitle($vitero_plugin->txt('edit_learning_progress_properties'));
-			$this->form->addItem($pres);
-
-			$num_appointments = $this->object->getNumberOfAppointmentsForSession();
-
-			$learning_progress = new ilCheckboxInputGUI($vitero_plugin->txt('activate_learning_progress'), 'learning_progress');
-			$learning_progress->setInfo($vitero_plugin->txt('activate_learning_progress_info'));
-
-			$minimum_percentage = new ilNumberInputGUI($vitero_plugin->txt("min_percentage"),"min_percentage");
-			$minimum_percentage->setInfo($vitero_plugin->txt("min_sessions_info"));
-			$minimum_percentage->setMaxValue(100);
-			$minimum_percentage->setMinValue(0);
-			$minimum_percentage->setMaxLength(3);
-			$minimum_percentage->setSize(3);
-			$minimum_percentage->setSuffix("%");
-			$minimum_percentage->setRequired(true);
-
-			$learning_progress->addSubItem($minimum_percentage);
-
-			$mode = new ilRadioGroupInputGUI($vitero_plugin->txt("mode"),"mode");
-			$mode->setRequired(true);
-
-			$one_session = new ilRadioOption($vitero_plugin->txt("one_session"),ilObjVitero::LP_MODE_ONE);
-			if($num_appointments > 1) {
-				$one_session->setDisabled(true);
-				$one_session->setInfo($vitero_plugin->txt("currently_multi_appointments"));
-			}
-			$mode->addOption($one_session);
-
-			$multi_session = new ilRadioOption($vitero_plugin->txt("multi_session"), ilObjVitero::LP_MODE_MULTI);
-			$minimum_sessions = new ilNumberInputGUI($vitero_plugin->txt("min_sessions"), "min_sessions");
-			$minimum_sessions->setInfo($vitero_plugin->txt("min_sessions_info"));
-			$minimum_sessions->setMinValue(1);
-			$minimum_sessions->setMaxLength(3);
-			$minimum_sessions->setSize(3);
-			$minimum_sessions->setRequired(true);
-			$multi_session->addSubItem($minimum_sessions);
-			if($num_appointments === 1){
-				$multi_session->setDisabled(true);
-				$multi_session->setInfo($vitero_plugin->txt("currently_one_appointment"));
-			}
-			$mode->addOption($multi_session);
-
-			$learning_progress->addSubItem($mode);
-
-			$this->form->addItem($learning_progress);
+			$this->addLearningProgressSettingsSection();
 		}
 
 		$this->form->addCommandButton("updateProperties", $this->txt("save"));
 
 		$this->form->setTitle($this->txt("edit_properties"));
 		$this->form->setFormAction($ilCtrl->getFormAction($this));
+	}
+
+	protected function addLearningProgressSettingsSection()
+	{
+		$vitero_plugin = ilViteroPlugin::getInstance();
+
+		$pres = new ilFormSectionHeaderGUI();
+		$pres->setTitle($vitero_plugin->txt('edit_learning_progress_properties'));
+		$this->form->addItem($pres);
+
+		$num_appointments = $this->object->getNumberOfAppointmentsForSession();
+
+		$learning_progress = new ilCheckboxInputGUI($vitero_plugin->txt('activate_learning_progress'), 'learning_progress');
+		$learning_progress->setInfo($vitero_plugin->txt('activate_learning_progress_info'));
+
+		$minimum_percentage = new ilNumberInputGUI($vitero_plugin->txt("min_percentage"),"min_percentage");
+		$minimum_percentage->setInfo($vitero_plugin->txt("min_sessions_info"));
+		$minimum_percentage->setMaxValue(100);
+		$minimum_percentage->setMinValue(0);
+		$minimum_percentage->setMaxLength(3);
+		$minimum_percentage->setSize(3);
+		$minimum_percentage->setSuffix("%");
+		$minimum_percentage->setRequired(true);
+
+		$learning_progress->addSubItem($minimum_percentage);
+
+		$mode = new ilRadioGroupInputGUI($vitero_plugin->txt("mode"),"mode");
+		$mode->setRequired(true);
+
+		$one_session = new ilRadioOption($vitero_plugin->txt("one_session"),ilObjVitero::LP_MODE_ONE);
+		if($num_appointments > 1) {
+			$one_session->setDisabled(true);
+			$one_session->setInfo($vitero_plugin->txt("currently_multi_appointments"));
+		}
+		$mode->addOption($one_session);
+
+		$multi_session = new ilRadioOption($vitero_plugin->txt("multi_session"), ilObjVitero::LP_MODE_MULTI);
+		$minimum_sessions = new ilNumberInputGUI($vitero_plugin->txt("min_sessions"), "min_sessions");
+		$minimum_sessions->setInfo($vitero_plugin->txt("min_sessions_info"));
+		$minimum_sessions->setMinValue(1);
+		$minimum_sessions->setMaxLength(3);
+		$minimum_sessions->setSize(3);
+		$minimum_sessions->setRequired(true);
+		$multi_session->addSubItem($minimum_sessions);
+
+		if($num_appointments === 1){
+			$multi_session->setDisabled(true);
+			$multi_session->setInfo($vitero_plugin->txt("currently_one_appointment"));
+		}
+
+		$mode->addOption($multi_session);
+
+		$learning_progress->addSubItem($mode);
+
+		$this->form->addItem($learning_progress);
+
 	}
 	
 	/**

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -835,7 +835,7 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 		$values["desc"] = $this->object->getDescription();
 		$values['learning_progress'] = $this->object->isLearningProgressActive();
 		$values['min_percentage'] = $this->object->getLearningProgressMinPercentage();
-		$values['mode'] = $this->object->getLearningProgressModeMulti();
+		$values['mode'] = $this->object->isLearningProgressModeMultiActive();
 		$values['min_sessions'] = $this->object->getLearningProgressMinSessions();
 
 		$this->form->setValuesByArray($values);
@@ -1609,12 +1609,12 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 
 			$appointments_after_deletion = $total_appointments - $number_app_to_delete;
 
-			if ($this->object->getLearningProgressModeMulti() && $appointments_after_deletion < 2) {
+			if ($this->object->isLearningProgressModeMultiActive() && $appointments_after_deletion < 2) {
 				ilUtil::sendFailure(ilViteroPlugin::getInstance()->txt('delete_info_minimum_app'), true);
 				$GLOBALS['ilCtrl']->redirect($this, 'showContent');
 			}
 
-			if (!$this->object->getLearningProgressModeMulti() && $appointments_after_deletion < 1) {
+			if (!$this->object->isLearningProgressModeMultiActive() && $appointments_after_deletion < 1) {
 				ilUtil::sendFailure(ilViteroPlugin::getInstance()->txt('delete_info_disable_lp'), true);
 				$GLOBALS['ilCtrl']->redirect($this, 'showContent');
 			}
@@ -2083,7 +2083,7 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 	public function canNotCreateAppointmentsByLearningProgressMode()
 	{
 		if($this->object->isLearningProgressActive()) {
-			if (!$this->object->getLearningProgressModeMulti() && ($this->object->getNumberOfAppointmentsForSession() >= 1)) {
+			if (!$this->object->isLearningProgressModeMultiActive() && ($this->object->getNumberOfAppointmentsForSession() >= 1)) {
 				return true;
 			}
 		}

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -724,7 +724,7 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 			$pres->setTitle($vitero_plugin->txt('edit_learning_progress_properties'));
 			$this->form->addItem($pres);
 
-			//TODO : Implement Appointments check, café mode etc.
+			$num_appointments = $this->object->getNumberOfAppointmentsForSession();
 
 			$learning_progress = new ilCheckboxInputGUI($vitero_plugin->txt('activate_learning_progress'), 'learning_progress');
 			$learning_progress->setInfo($vitero_plugin->txt('activate_learning_progress_info'));
@@ -744,6 +744,10 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 			$mode->setRequired(true);
 
 			$one_session = new ilRadioOption($vitero_plugin->txt("one_session"),ilObjVitero::LP_MODE_ONE);
+			if($num_appointments > 1) {
+				$one_session->setDisabled(true);
+				$one_session->setInfo($vitero_plugin->txt("currently_multi_appointments"));
+			}
 			$mode->addOption($one_session);
 
 			$multi_session = new ilRadioOption($vitero_plugin->txt("multi_session"), ilObjVitero::LP_MODE_MULTI);
@@ -754,6 +758,10 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 			$minimum_sessions->setSize(3);
 			$minimum_sessions->setRequired(true);
 			$multi_session->addSubItem($minimum_sessions);
+			if($num_appointments === 1){
+				$multi_session->setDisabled(true);
+				$multi_session->setInfo($vitero_plugin->txt("currently_one_appointment"));
+			}
 			$mode->addOption($multi_session);
 
 			$learning_progress->addSubItem($mode);

--- a/classes/class.ilObjViteroGUI.php
+++ b/classes/class.ilObjViteroGUI.php
@@ -1589,7 +1589,6 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 	}
 
 	/**
-	 * TODO -> shoud we move this method to another place?
 	 * @param $book ViteroBookingResponse
 	 * return void
 	 */
@@ -1603,7 +1602,6 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 			$start->increment(IL_CAL_YEAR,-5);
 			$end->increment(IL_CAL_YEAR,1);
 
-			//todo extract the logic of start, end and calculate booking appointments to a method.
 			$number_app_to_delete = 0;
 			foreach (ilViteroUtils::calculateBookingAppointments($start, $end, $book->booking) as $dl) {
 				$number_app_to_delete++;
@@ -1611,7 +1609,6 @@ class ilObjViteroGUI extends ilObjectPluginGUI
 
 			$appointments_after_deletion = $total_appointments - $number_app_to_delete;
 
-			//todo extract this to a method.
 			if ($this->object->getLearningProgressModeMulti() && $appointments_after_deletion < 2) {
 				ilUtil::sendFailure(ilViteroPlugin::getInstance()->txt('delete_info_minimum_app'), true);
 				$GLOBALS['ilCtrl']->redirect($this, 'showContent');

--- a/classes/class.ilViteroBookingSoapConnector.php
+++ b/classes/class.ilViteroBookingSoapConnector.php
@@ -253,6 +253,28 @@ class ilViteroBookingSoapConnector extends ilViteroSoapConnector
 		}
 	}
 
+	public function getBookingByBookingTimeId($a_booking_time_id)
+	{
+		try{
+			$this->initClient();
+
+			$req = new stdClass();
+			$req->bookingtimeid = $a_booking_time_id;
+			$req->timezone = self::WS_TIMEZONE;
+
+			$ret = $this->getClient()->getBookingByBookingTimeId($req);
+
+			return $ret;
+		}
+		catch (SoapFault $e)
+		{
+			$code = $this->parseErrorCode($e);
+			$GLOBALS['ilLog']->write(__METHOD__.': Get Booking By BookingTimeId id failed with message code: '.$code);
+			$GLOBALS['ilLog']->write(__METHOD__.': Last request: '.$this->getClient()->__getLastRequest());
+			throw new ilViteroConnectorException($e->getMessage(),$code);
+		}
+	}
+
 	public function deleteBooking($a_id)
 	{
 		try {

--- a/classes/class.ilViteroBookingTableGUI.php
+++ b/classes/class.ilViteroBookingTableGUI.php
@@ -287,8 +287,11 @@ class ilViteroBookingTableGUI extends ilTable2GUI
 				$GLOBALS['ilCtrl']->getLinkTarget($this->getParentObject(),'confirmDeleteBooking')
 			);
 		}
-		$this->tpl->setVariable('ACTION_PART',$list->getHTML());
-
+		if($a_set['has_actions']){
+			$this->tpl->setVariable('ACTION_PART',$list->getHTML());
+		} else {
+			$this->tpl->setVariable('ACTION_PART',"");
+		}
 
 	}
 
@@ -441,6 +444,13 @@ class ilViteroBookingTableGUI extends ilTable2GUI
 					$repend = ilViteroUtils::parseSoapDate($booking->repetitionenddate);
 					$booking_list[$counter]['ends'] = ilDatePresentation::formatDate(new ilDate($repend->get(IL_CAL_UNIX),IL_CAL_UNIX));
 				}
+
+				if($bend->get(IL_CAL_UNIX) < time()) {
+					$booking_list[$counter]['has_actions'] = false;
+				} else {
+					$booking_list[$counter]['has_actions'] = true;
+				}
+
 				$counter++;
 			}
 		}

--- a/classes/class.ilViteroConfigGUI.php
+++ b/classes/class.ilViteroConfigGUI.php
@@ -419,13 +419,24 @@ class ilViteroConfigGUI extends ilPluginConfigGUI
 	 */
 	private function hasAccessToLearningProgress()
 	{
+		if(ilObjUserTracking::_enabledLearningProgress() && $this->hasCustomerMonitoringMode())
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	private function hasCustomerMonitoringMode()
+	{
 		$this->getPluginObject()->includeClass('class.ilViteroLicenceSoapConnector.php');
 
 		$licence_connector = new ilViteroLicenceSoapConnector();
-		
+
 		$modules = $licence_connector->getModulesForCustomer(ilViteroSettings::getInstance()->getCustomer());
 
-		foreach($modules->modules->module as $module) {
+		foreach($modules->modules->module as $module)
+		{
 			if($module->type == "MONITORING"){
 				return true;
 			}

--- a/classes/class.ilViteroConfigGUI.php
+++ b/classes/class.ilViteroConfigGUI.php
@@ -414,7 +414,6 @@ class ilViteroConfigGUI extends ilPluginConfigGUI
 
 	/**
 	 * TODO: MISSING THE STATISTIC MODULE!
-	 * TODO: This method should be in a non GUI class
 	 */
 	private function hasAccessToLearningProgress()
 	{

--- a/classes/class.ilViteroConfigGUI.php
+++ b/classes/class.ilViteroConfigGUI.php
@@ -313,6 +313,19 @@ class ilViteroConfigGUI extends ilPluginConfigGUI
 		);
 		$gpa->setValue($settings->getStandardGracePeriodAfter());
 		$form->addItem($gpa);
+
+		//TODO FINISH THIS CHECKBOX HERE
+
+		//ALSO TO DISPLAY THIS OPTION WE HAVE TO CHECK VITERO
+		//Monitor-Modul“ freigeschaltet ist und die eingesetzte vitero-Server-Version das „Statistik-Modul bereitstellt.
+
+		//check if lp enabled in administration globaly
+		$learning_progress = new ilCheckboxInputGUI($this->getPluginObject()->txt('activate_learning_progress'), 'learning_progress');
+		$learning_progress->setChecked($settings->isLearningProgressEnabled());
+
+		$learning_progress->setInfo($this->getPluginObject()->txt('activate_learning_progress_info'));
+		$form->addItem($learning_progress);
+
 		return $form;
 	}
 
@@ -355,6 +368,7 @@ class ilViteroConfigGUI extends ilPluginConfigGUI
 			$settings->enablePhoneDialOutParticipants($form->getInput('phone_dial_out_part'));
 			$settings->enableMobileAccess($form->getInput('mobile'));
 			$settings->enableSessionRecorder($form->getInput('recorder'));
+			$settings->enableLearningProgress($form->getInput('learning_progress'));
 			$settings->save();
 
 			ilUtil::sendSuccess($lng->txt('settings_saved'), true);

--- a/classes/class.ilViteroConfigGUI.php
+++ b/classes/class.ilViteroConfigGUI.php
@@ -415,11 +415,10 @@ class ilViteroConfigGUI extends ilPluginConfigGUI
 	/**
 	 * TODO: MISSING THE STATISTIC MODULE!
 	 * TODO: This method should be in a non GUI class
-	 * @throws ilViteroConnectorException
 	 */
 	private function hasAccessToLearningProgress()
 	{
-		if(ilObjUserTracking::_enabledLearningProgress() && $this->hasCustomerMonitoringMode())
+		if(ilObjUserTracking::_enabledLearningProgress() && ilViteroUtils::hasCustomerMonitoringMode())
 		{
 			return true;
 		}
@@ -427,22 +426,5 @@ class ilViteroConfigGUI extends ilPluginConfigGUI
 		return false;
 	}
 
-	private function hasCustomerMonitoringMode()
-	{
-		$this->getPluginObject()->includeClass('class.ilViteroLicenceSoapConnector.php');
-
-		$licence_connector = new ilViteroLicenceSoapConnector();
-
-		$modules = $licence_connector->getModulesForCustomer(ilViteroSettings::getInstance()->getCustomer());
-
-		foreach($modules->modules->module as $module)
-		{
-			if($module->type == "MONITORING"){
-				return true;
-			}
-		}
-
-		return false;
-	}
 }
 ?>

--- a/classes/class.ilViteroConfigGUI.php
+++ b/classes/class.ilViteroConfigGUI.php
@@ -315,16 +315,16 @@ class ilViteroConfigGUI extends ilPluginConfigGUI
 		$form->addItem($gpa);
 
 		//TODO FINISH THIS CHECKBOX HERE
+		//Step 1 check if lp enabled in administration globaly
+		//Step 2 check Statistik-Modul
+		if($this->hasAccessToLearningProgress())
+		{
+			$learning_progress = new ilCheckboxInputGUI($this->getPluginObject()->txt('activate_learning_progress'), 'learning_progress');
+			$learning_progress->setChecked($settings->isLearningProgressEnabled());
 
-		//ALSO TO DISPLAY THIS OPTION WE HAVE TO CHECK VITERO
-		//Monitor-Modul“ freigeschaltet ist und die eingesetzte vitero-Server-Version das „Statistik-Modul bereitstellt.
-
-		//check if lp enabled in administration globaly
-		$learning_progress = new ilCheckboxInputGUI($this->getPluginObject()->txt('activate_learning_progress'), 'learning_progress');
-		$learning_progress->setChecked($settings->isLearningProgressEnabled());
-
-		$learning_progress->setInfo($this->getPluginObject()->txt('activate_learning_progress_info'));
-		$form->addItem($learning_progress);
+			$learning_progress->setInfo($this->getPluginObject()->txt('activate_learning_progress_info'));
+			$form->addItem($learning_progress);
+		}
 
 		return $form;
 	}
@@ -412,5 +412,26 @@ class ilViteroConfigGUI extends ilPluginConfigGUI
 		$tpl->setContent($table->getHTML());
 	}
 
+	/**
+	 * TODO: MISSING THE STATISTIC MODULE!
+	 * TODO: This method should be in a non GUI class
+	 * @throws ilViteroConnectorException
+	 */
+	private function hasAccessToLearningProgress()
+	{
+		$this->getPluginObject()->includeClass('class.ilViteroLicenceSoapConnector.php');
+
+		$licence_connector = new ilViteroLicenceSoapConnector();
+		
+		$modules = $licence_connector->getModulesForCustomer(ilViteroSettings::getInstance()->getCustomer());
+
+		foreach($modules->modules->module as $module) {
+			if($module->type == "MONITORING"){
+				return true;
+			}
+		}
+
+		return false;
+	}
 }
 ?>

--- a/classes/class.ilViteroGroupSoapConnector.php
+++ b/classes/class.ilViteroGroupSoapConnector.php
@@ -192,5 +192,24 @@ class ilViteroGroupSoapConnector extends ilViteroSoapConnector
 	{
 		return self::WSDL_NAME;
 	}
+
+	public function getGroupListByCustomer($customer_id)
+	{
+		try {
+			$this->initClient();
+
+			$request = new stdClass();
+			$request->customerid = $customer_id;
+
+			return $this->getClient()->getGroupListByCustomer($request);
+		}
+		catch(SoapFault $e)
+		{
+			$code = $this->parseErrorCode($e);
+			$GLOBALS['ilLog']->write(__METHOD__.': Change group role failed with message code: '.$code);
+			$GLOBALS['ilLog']->write(__METHOD__.': Last request: '.$this->getClient()->__getLastRequest());
+			throw new ilViteroConnectorException($e->getMessage(),$code);
+		}
+	}
 }
 ?>

--- a/classes/class.ilViteroLearningProgress.php
+++ b/classes/class.ilViteroLearningProgress.php
@@ -133,45 +133,6 @@ class ilViteroLearningProgress
 	}
 
 	/**
-	 * @param $a_user_recording
-	 * @param $a_session_start
-	 * @param $a_session_end
-	 * @return array
-	 */
-	public function getUserSessionsAttended($a_user_recording, $a_session_start, $a_session_end)
-	{
-		$user_sessions_attended = array();
-
-		//TODO no foreach here, we have only one userrecording object per appointment.
-		foreach($a_user_recording as $record)
-		{
-			$user_start = strtotime($record['userstart']);
-			$user_end = strtotime($record['userend']);
-
-			//time in real scheduled session time period.
-			$real_start = $this->getRealStartDateTime($a_session_start, $user_start);
-			$real_end   = $this->getRealEndDateTime($a_session_end, $user_end);
-
-			$user_time_spent = $real_end - $real_start;
-
-			$session_duration = $a_session_end - $a_session_start;
-
-			$user_percent_attended = floor($user_time_spent * 100 / $session_duration);
-
-			$user_id = $this->user_mapping->getIUserId($record["userid"]);
-			$userrecording_id = $record['userrecordingid'];
-
-			$user_sessions_attended[] = array(
-				"userrecordingid"   => $userrecording_id,
-				"userid"            => $user_id,
-				"percentage"        => $user_percent_attended
-			);
-		}
-
-		return $user_sessions_attended;
-	}
-
-	/**
 	 * @param $a_completed_sessions
 	 * @return array
 	 */

--- a/classes/class.ilViteroLearningProgress.php
+++ b/classes/class.ilViteroLearningProgress.php
@@ -52,22 +52,29 @@ class ilViteroLearningProgress
 		$end = $end->getUnixTime();
 		$end = date('YmtHi',$end);
 
+		ilLoggerFactory::getRootLogger()->debug("Start date = ".$start);
+		ilLoggerFactory::getRootLogger()->debug("End date = ".$end);
+		ilLoggerFactory::getRootLogger()->debug("Customer id = ".$customer_id);
+
+
 		//TODO uncomment this and remove dummy array.
-		//$session_and_user_recordings = $statistic_connector->getSessionAndUserRecordingsByTimeSlot($start, $end, $customer_id);
+		$session_and_user_recordings = $statistic_connector->getSessionAndUserRecordingsByTimeSlot('201906281030', '201906281145', $customer_id);
+
+		ilLoggerFactory::getRootLogger()->dump($session_and_user_recordings);
 
 		//TODO parse the recordings
 		//$session_and_user_recordings = $this->parseRecordings($session_and_user_recordings);
-		$session_and_user_recordings = $this->dummyArray();
+		//$session_and_user_recordings = $this->dummyArray();
 
 		// READ ONLY SESSIONS WITH FUTURE APPOINTMENTS.
-		$usersAndStatusToUpdate = $this->getUsersAndStatusToUpdate($session_and_user_recordings);
+		/*$usersAndStatusToUpdate = $this->getUsersAndStatusToUpdate($session_and_user_recordings);
 		ilLoggerFactory::getRootLogger()->dump($usersAndStatusToUpdate);
 		foreach ($usersAndStatusToUpdate as $status_data)
 		{
 			//TODO-> This is the current process ending.
 			$this->updateUserRecordingAttendance($status_data['userrecordingid'], $status_data['userid'], $status_data['percentage']);
 		}
-		ilLoggerFactory::getRootLogger()->dump($usersAndStatusToUpdate);
+		ilLoggerFactory::getRootLogger()->dump($usersAndStatusToUpdate);*/
 	}
 
 	/**

--- a/classes/class.ilViteroLearningProgress.php
+++ b/classes/class.ilViteroLearningProgress.php
@@ -73,6 +73,11 @@ class ilViteroLearningProgress
 		{
 			$ilias_object_id = ilObjVitero::lookupObjIdByGroupId($session_user_recording->groupid);
 
+			//Omit this group id if there is not an ILIAS vitero session assigned.
+			if($ilias_object_id == 0) {
+				continue;
+			}
+
 			$this->vitero_object->setId($ilias_object_id);
 
 			$this->vitero_object->readLearningProgressSettings();
@@ -120,12 +125,8 @@ class ilViteroLearningProgress
 
 			}
 
-			//TODO : Is this ok????
 			ilLPStatusWrapper::_refreshStatus($ilias_object_id);
 		}
-
-
-
 	}
 
 	/**

--- a/classes/class.ilViteroLearningProgress.php
+++ b/classes/class.ilViteroLearningProgress.php
@@ -29,9 +29,10 @@ class ilViteroLearningProgress
 
 	/**
 	 * Booking in vitero = Appointment in ILIAS
+	 * @param int vitero group id $a_vitero_group_id
 	 * @throws ilDateTimeException
 	 */
-	public function updateLearningProgress()
+	public function updateLearningProgress(int $a_vgroup_id = 0)
 	{
 		$statistic_connector = new ilViteroStatisticSoapConnector();
 		$booking_connector = new ilViteroBookingSoapConnector();
@@ -41,7 +42,7 @@ class ilViteroLearningProgress
 
 		$time_slot = $this->getTimeSlotToGetViteroRecordings();
 
-		$session_and_user_recordings = $statistic_connector->getSessionAndUserRecordingsByTimeSlot($time_slot['start'], $time_slot['end'], $customer_id);
+		$session_and_user_recordings = $statistic_connector->getSessionAndUserRecordingsByTimeSlot($time_slot['start'], $time_slot['end'], $customer_id, $a_vgroup_id);
 
 		if(is_object($session_and_user_recordings->sessionrecording))
 		{

--- a/classes/class.ilViteroLearningProgress.php
+++ b/classes/class.ilViteroLearningProgress.php
@@ -65,7 +65,7 @@ class ilViteroLearningProgress
 
 			$this->vitero_object->setId($ilias_object_id);
 
-			$this->vitero_object->readLearningProgressSettings();
+			$this->vitero_object->isLearningProgressModeMultiActive();
 
 			if($this->vitero_object->isLearningProgressActive())
 			{
@@ -127,7 +127,7 @@ class ilViteroLearningProgress
 		foreach ($a_completed_sessions as $user_id => $total_passed)
 		{
 			$status = self::NOT_PASSED;
-			if($this->vitero_object->getLearningProgressModeMulti())
+			if($this->vitero_object->isLearningProgressModeMultiActive())
 			{
 				if($total_passed >= $this->vitero_object->getLearningProgressMinSessions())
 				{

--- a/classes/class.ilViteroLearningProgress.php
+++ b/classes/class.ilViteroLearningProgress.php
@@ -11,6 +11,7 @@ class ilViteroLearningProgress
 {
 	const PASSED = "passed";
 	const NOT_PASSED = "not passed";
+	const CRON_PLUGIN_ID = "xvitc";
 
 	/**
 	 * @var ilObjVitero
@@ -21,6 +22,7 @@ class ilViteroLearningProgress
 	 * @var ilViteroUserMapping
 	 */
 	protected $user_mapping;
+
 
 	public function __construct()
 	{
@@ -41,14 +43,26 @@ class ilViteroLearningProgress
 		$settings = new ilViteroSettings();
 		$customer_id = $settings->getCustomer();
 
-		//TODO Improve this date stuff
-		$start_range = new ilDateTime(time(),IL_CAL_UNIX);
-		$end_range = clone $start_range;
+		//TODO get last plugin execution and get all the sessions with appointments in the future and from the day before just in case.
+		$cron_data = ilCronManager::getCronJobData(self::CRON_PLUGIN_ID);
+		$last_cron_ejecution_date = $cron_data[0]['running_ts'];
 
-		$start_range->increment(IL_CAL_YEAR,-5);
+		//first cron execution will start dealing with events from 5 years ago. Later executions will start from current date - 1 day
+		if($last_cron_ejecution_date > 0)
+		{
+			$start_range = new ilDateTime($last_cron_ejecution_date,IL_CAL_UNIX);
+			$start_range->increment(IL_CAL_DAY,-1);
+		}
+		else
+		{
+			$start_range = new ilDateTime(time(),IL_CAL_UNIX);
+			$start_range->increment(IL_CAL_YEAR,-5);
+		}
+
 		$start_unix = $start_range->getUnixTime();
 		$start_str = date('YmtHi',$start_unix);
 
+		$end_range = new ilDateTime(time(),IL_CAL_UNIX);
 		$end_range->increment(IL_CAL_YEAR,1);
 		$end_unix = $end_range->getUnixTime();
 		$end_str = date('YmtHi',$end_unix);

--- a/classes/class.ilViteroLearningProgress.php
+++ b/classes/class.ilViteroLearningProgress.php
@@ -70,7 +70,7 @@ class ilViteroLearningProgress
 
 			$this->vitero_object->readLearningProgressSettings();
 
-			if($this->vitero_object->getLearningProgress())
+			if($this->vitero_object->isLearningProgressActive())
 			{
 				$booking = $booking_connector->getBookingByBookingTimeId($session_user_recording->bookingid);
 

--- a/classes/class.ilViteroLearningProgress.php
+++ b/classes/class.ilViteroLearningProgress.php
@@ -65,7 +65,7 @@ class ilViteroLearningProgress
 
 			$this->vitero_object->setId($ilias_object_id);
 
-			$this->vitero_object->isLearningProgressModeMultiActive();
+			$this->vitero_object->readLearningProgressSettings();
 
 			if($this->vitero_object->isLearningProgressActive())
 			{

--- a/classes/class.ilViteroLearningProgress.php
+++ b/classes/class.ilViteroLearningProgress.php
@@ -76,7 +76,6 @@ class ilViteroLearningProgress
 
 				if($session_user_recording->sessionend >= $booking->booking->start)
 				{
-					$user_time_attended = 0;
 					$user_percent_attended = 0;
 
 					//parse vitero string dates to ilDateTime

--- a/classes/class.ilViteroLearningProgress.php
+++ b/classes/class.ilViteroLearningProgress.php
@@ -32,7 +32,6 @@ class ilViteroLearningProgress
 
 	/**
 	 * Booking in vitero = Appointment in ILIAS
-	 * TODO pending real sessions in vitero platform to test this.
 	 * @throws ilDateTimeException
 	 */
 	public function updateLearningProgress()
@@ -56,8 +55,8 @@ class ilViteroLearningProgress
 			$session_and_user_recordings = $session_and_user_recordings->sessionrecording;
 		}
 
-		//TODO: The booking id here is not a real booking id because vitero needs this to keep backward compatibility.
-		//TODO: The booking id is a bookingTimeId and we can get a booking obj. via getBookingTimeId(bookingTimeId)
+		// Notice: The booking id here is not a real booking id because vitero needs this to keep backward compatibility.
+		// Notice: The booking id is a bookingTimeId and we can get a booking obj. via getBookingTimeId(bookingTimeId)
 		foreach ($session_and_user_recordings as $session_user_recording)
 		{
 			$ilias_object_id = ilObjVitero::lookupObjIdByGroupId($session_user_recording->groupid);
@@ -167,7 +166,6 @@ class ilViteroLearningProgress
 				"userid"            => $user_id,
 				"percentage"        => $user_percent_attended
 			);
-		//$user_sessions_attended[$user_id][$recording_id] = $user_sessions_attended[$user_id][$recording_id] + $user_time_spent;
 		}
 
 		return $user_sessions_attended;
@@ -266,7 +264,12 @@ class ilViteroLearningProgress
 		$db->manipulate($sql);
 	}
 
-
+	/**
+	 * Gets an array with starting date and ending date
+	 * @return array
+	 * @throws ilDatabaseException
+	 * @throws ilDateTimeException
+	 */
 	public function getTimeSlotToGetViteroRecordings()
 	{
 		$last_cron_ejecution_date = ilViteroUtils::getLastSyncDate();

--- a/classes/class.ilViteroLearningProgress.php
+++ b/classes/class.ilViteroLearningProgress.php
@@ -120,19 +120,6 @@ class ilViteroLearningProgress
 	}
 
 	/**
-	 * Filter for sessions
-	 * @param $recordings
-	 * @return mixed
-	 */
-	public function parseRecordings($recordings)
-	{
-		// Return only recordings if LP is active +
-		// user finished the session(userrecording->userend) +
-		// session is finished(getSessionAndUserRecordingsByTimeSlotRequest->timeslotend)
-		return $recordings;
-	}
-
-	/**
 	 * @param $a_completed_sessions
 	 * @return array
 	 */

--- a/classes/class.ilViteroLearningProgress.php
+++ b/classes/class.ilViteroLearningProgress.php
@@ -1,8 +1,5 @@
 <?php
 /**
- * TODO remove dummy array data
- * TODO type hints
- * TODO constants should be = as ilLPStatus::LP_STATUS_COMPLETED_NUM etc.
  * Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE
  *
  * @author Jesús López Reyes <lopez@leifos.com>

--- a/classes/class.ilViteroLearningProgress.php
+++ b/classes/class.ilViteroLearningProgress.php
@@ -1,0 +1,369 @@
+<?php
+/**
+ * TODO remove dummy array data
+ * TODO type hints
+ * TODO constants should be = as ilLPStatus::LP_STATUS_COMPLETED_NUM etc.
+ * Copyright (c) 1998-2010 ILIAS open source, Extended GPL, see docs/LICENSE
+ *
+ * @author Jesús López Reyes <lopez@leifos.com>
+ */
+class ilViteroLearningProgress
+{
+	const PASSED = "passed";
+	const NOT_PASSED = "not passed";
+
+	/**
+	 * @var ilObjVitero
+	 */
+	protected $vitero_object;
+
+	/**
+	 * @var ilViteroUserMapping
+	 */
+	protected $user_mapping;
+
+	public function __construct()
+	{
+		$this->vitero_object = new ilObjVitero();
+		$this->user_mapping = new ilViteroUserMapping();
+	}
+
+	/**
+	 * TODO pending real sessions in vitero platform to test this.
+	 * @throws ilDateTimeException
+	 */
+	public function updateLearningProgress()
+	{
+		$statistic_connector = new ilViteroStatisticSoapConnector();
+
+		$settings = new ilViteroSettings();
+		$customer_id = $settings->getCustomer();
+
+		//TODO define properly these slots. Store them if necessary (current end time will be next start)
+
+		$start = new ilDateTime(time(),IL_CAL_UNIX);//2019-06-24 17:04:57
+
+		$end = clone $start;
+
+		$start->increment(IL_CAL_YEAR,-5);
+		$start = $start->getUnixTime();
+		$start = date('YmtHi',$start);
+		$end->increment(IL_CAL_YEAR,1);
+		$end = $end->getUnixTime();
+		$end = date('YmtHi',$end);
+
+		//TODO uncomment this and remove dummy array.
+		//$session_and_user_recordings = $statistic_connector->getSessionAndUserRecordingsByTimeSlot($start, $end, $customer_id);
+
+		//TODO parse the recordings
+		//$session_and_user_recordings = $this->parseRecordings($session_and_user_recordings);
+		$session_and_user_recordings = $this->dummyArray();
+
+		// READ ONLY SESSIONS WITH FUTURE APPOINTMENTS.
+		$usersAndStatusToUpdate = $this->getUsersAndStatusToUpdate($session_and_user_recordings);
+		ilLoggerFactory::getRootLogger()->dump($usersAndStatusToUpdate);
+		foreach ($usersAndStatusToUpdate as $status_data)
+		{
+			//TODO-> This is the current process ending.
+			$this->updateUserRecordingAttendance($status_data['userrecordingid'], $status_data['userid'], $status_data['percentage']);
+		}
+		ilLoggerFactory::getRootLogger()->dump($usersAndStatusToUpdate);
+	}
+
+	/**
+	 * Filter for sessions
+	 * @param $recordings
+	 * @return mixed
+	 */
+	public function parseRecordings($recordings)
+	{
+		// Return only recordings if LP is active +
+		// user finished the session(userrecording->userend) +
+		// session is finished(getSessionAndUserRecordingsByTimeSlotRequest->timeslotend)
+		return $recordings;
+	}
+
+	public function dummyArray()
+	{
+		$array_user_recording = array();
+
+		$array_user_recording[] = array(
+			"userstart" => "201906251545",
+			"userend" => "201906251615",
+			"userid" => 3,
+			"sessionrecordingid" => 1,
+			"userrecordingid" => 1
+		);
+
+		/*$array_user_recording[] = array(
+			"userstart" => "201906251640",
+			"userend" => "201906251645",
+			"userid" => 3,
+			"sessionrecordingid" => 1,
+			"userrecordingid" => 2
+		);*/
+
+		/*$array_user_recording[] = array(
+			"userstart" => "201906251650",
+			"userend" => "201906251715",
+			"userid" => 3,
+			"sessionrecordingid" => 1,
+			"userrecordingid" => 3
+		);*/
+
+		$array_user_recording[] = array(
+			"userstart" => "201906251700",
+			"userend" => "201906251715",
+			"userid" => 3,
+			"sessionrecordingid" => 2,
+			"userrecordingid" => 4
+		);
+
+		$array_user_recording[] = array(
+			"userstart" => "201906251605",
+			"userend" => "201906251715",
+			"userid" => 4,
+			"sessionrecordingid" => 1,
+			"userrecordingid" => 5
+		);
+
+		$session_and_user_recordings = array();
+		$session_and_user_recordings[] = array(
+			"groupid" => 4,
+			"sessionstart" => "201906251600",
+			"sessionend" => "201906251700",
+			"userrecording" => $array_user_recording
+		);
+
+		return $session_and_user_recordings;
+	}
+
+	/**
+	 * get the moment when the session started for the user
+	 * @param $a_session_start
+	 * @param $a_user_start
+	 * @return mixed
+	 */
+	public function getRealStartDateTime($a_session_start, $a_user_start)
+	{
+		$real_start = $a_session_start;
+
+		if($a_user_start > $a_session_start){
+			$real_start = $a_user_start;
+		}
+
+		return $real_start;
+	}
+
+	/**
+	 * Get the moment when the session finished for the user
+	 * @param $a_session_end
+	 * @param $a_user_end
+	 * @return mixed
+	 */
+	public function getRealEndDateTime($a_session_end, $a_user_end)
+	{
+		$real_end = $a_session_end;
+
+		if($a_user_end < $a_session_end) {
+			$real_end = $a_user_end;
+		}
+
+		return $real_end;
+	}
+
+	/**
+	 * @param $a_recordings
+	 * @return array
+	 */
+	public function getUsersAndStatusToUpdate($a_recordings)
+	{
+		$sessions_user_data = array();
+
+		foreach($a_recordings as $recording)
+		{
+			$ilias_object_id = ilObjVitero::lookupObjIdByGroupId($recording['groupid']);
+
+			$this->vitero_object->setId($ilias_object_id);
+
+			$this->vitero_object->readLearningProgressSettings();
+
+			if($this->vitero_object->getLearningProgress())
+			{
+				$session_start  = strtotime($recording['sessionstart']);
+				$session_end    = strtotime($recording['sessionend']);
+
+				$sessions_user_data = $this->getUserSessionsAttended($recording['userrecording'], $session_start, $session_end);
+			}
+		}
+
+		return $sessions_user_data;
+	}
+
+	/**
+	 * @param $a_user_recording
+	 * @param $a_session_start
+	 * @param $a_session_end
+	 * @return array
+	 */
+	public function getUserSessionsAttended($a_user_recording, $a_session_start, $a_session_end)
+	{
+		$user_sessions_attended = array();
+
+		foreach($a_user_recording as $record)
+		{
+			//TODO: USER RECORDINGS ALWAYS HAVE USER START AND USER END  datetime. This if maybe is not needed.
+			//We only calculate the Learning Progress if the user loged out from vitero session.
+			if($record['userend'] > 0)
+			{
+				$user_start = strtotime($record['userstart']);
+				$user_end = strtotime($record['userend']);
+
+				//time in real scheduled session time period.
+				$real_start = $this->getRealStartDateTime($a_session_start, $user_start);
+				$real_end   = $this->getRealEndDateTime($a_session_end, $user_end);
+
+				$user_time_spent = $real_end - $real_start;
+
+				$session_duration = $a_session_end - $a_session_start;
+
+				$user_percent_attended = floor($user_time_spent * 100 / $session_duration);
+
+				$user_id = $this->user_mapping->getIUserId($record["userid"]);
+				$userrecording_id = $record['userrecordingid'];
+
+				$user_sessions_attended[] = array(
+					"userrecordingid"   => $userrecording_id,
+					"userid"            => $user_id,
+					"percentage"        => $user_percent_attended
+				);
+				//$user_sessions_attended[$user_id][$recording_id] = $user_sessions_attended[$user_id][$recording_id] + $user_time_spent;
+			}
+		}
+
+		return $user_sessions_attended;
+	}
+
+	/**
+	 * @param $a_completed_sessions
+	 * @return array
+	 */
+	public function getUsersStatus($a_completed_sessions)
+	{
+		$users_status = array();
+
+		foreach ($a_completed_sessions as $user_id => $total_passed)
+		{
+			$status = self::NOT_PASSED;
+			if($this->vitero_object->getLearningProgressModeMulti())
+			{
+				if($total_passed >= $this->vitero_object->getLearningProgressMinSessions())
+				{
+					$status = self::PASSED;
+				}
+			}
+			else if($total_passed > 0)
+			{
+				$status = self::PASSED;
+			}
+
+			$users_status[] = array(
+				"user_id"   => $user_id,
+				"obj_id"    => $this->vitero_object->getId(),
+				"status"    => $status
+			);
+		}
+
+		return $users_status;
+	}
+
+	/**
+	 * @param $a_user_sessions_attended
+	 * @param $a_session_duration
+	 * @param $a_lp_min_percent
+	 * @return array
+	 */
+	public function getCompletedSessions($a_user_sessions_attended, $a_session_duration, $a_lp_min_percent)
+	{
+		$completed_sessions = array();
+
+		foreach($a_user_sessions_attended as $user_id => $attendance)
+		{
+			$attended = 0;
+			foreach($attendance as $session => $seconds)
+			{
+				$user_percent_attended = floor($seconds * 100 / $a_session_duration);
+
+				if($user_percent_attended >= $a_lp_min_percent)
+				{
+					$attended++;
+				}
+			}
+			$completed_sessions[$user_id] = $attended;
+		}
+
+		return $completed_sessions;
+	}
+
+	/**
+	 * @param $a_recording_id
+	 * @param $a_recording_user_id
+	 * @param $user_percent_attended
+	 */
+	public function updateUserRecordingAttendance($a_userrecording_id, $a_recording_user_id, $a_user_percent_attended)
+	{
+		if($this->isNotUserRecordingStoredInDB($a_userrecording_id))
+		{
+			$this->insertUserRecording($a_userrecording_id, $a_recording_user_id, $a_user_percent_attended);
+		}
+
+	}
+
+	/**
+	 * @param $a_recording_id
+	 * @return bool
+	 * @throws ilDatabaseException
+	 */
+	protected function isNotUserRecordingStoredInDB($a_recording_id)
+	{
+		global $DIC;
+
+		$db = $DIC->database();
+
+		$query = 'SELECT user_id FROM rep_robj_xvit_recs'.
+			' WHERE recording_id = '.$db->quote($a_recording_id,'integer');
+
+		$res = $db->query($query);
+
+		while($row = $res->fetchRow(DB_FETCHMODE_OBJECT))
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param $a_recording_id
+	 * @param $a_user_id
+	 * @param $a_user_percent_attended
+	 */
+	protected function insertUserRecording($a_userrecording_id, $a_user_id, $a_user_percent_attended)
+	{
+		global $DIC;
+
+		$db = $DIC->database();
+
+		$sql = 'INSERT INTO rep_robj_xvit_recs (user_id,obj_id,recording_id,percentage) ' .
+			'VALUES(' .
+			$db->quote($a_user_id, 'integer') . ', ' .
+			$db->quote($this->vitero_object->getId(), 'integer') . ', ' .
+			$db->quote($a_userrecording_id, 'integer') . ', ' .
+			$db->quote($a_user_percent_attended,'integer') .
+			')';
+
+		ilLoggerFactory::getRootLogger()->debug("INSERT = ".$sql);
+
+		$db->manipulate($sql);
+	}
+}

--- a/classes/class.ilViteroPlugin.php
+++ b/classes/class.ilViteroPlugin.php
@@ -112,6 +112,13 @@ class ilViteroPlugin extends ilRepositoryObjectPlugin
 		$settings = new ilSetting('vitero_config');
 		$settings->deleteAll();
 	}
-	
+
+	//Method called by external cron job plugin
+	public function updateLearningProgress()
+	{
+		$vitero_lp = new ilViteroLearningProgress();
+		$vitero_lp->updateLearningProgress();
+	}
+
 }
 ?>

--- a/classes/class.ilViteroSettings.php
+++ b/classes/class.ilViteroSettings.php
@@ -32,6 +32,7 @@ class ilViteroSettings
 	private $phone_dial_out_part = false;
 	private $mobile_access_enabled = false;
 	private $session_recorder = false;
+	private $enable_learning_progress = false;
 
 	private $grace_period_before = 15;
 	private $grace_period_after = 15;
@@ -219,6 +220,16 @@ class ilViteroSettings
 		return $this->mtom_cert;
 	}
 
+	public function enableLearningProgress($a_stat)
+	{
+		$this->enable_learning_progress = $a_stat;
+	}
+
+	public function isLearningProgressEnabled()
+	{
+		return $this->enable_learning_progress;
+	}
+
 
 	/**
 	 * Save settings
@@ -244,6 +255,7 @@ class ilViteroSettings
 		$this->getStorage()->set('phone_dial_out_participants',$this->isPhoneDialOutParticipantsEnabled());
 		$this->getStorage()->set('mobile', (int) $this->isMobileAccessEnabled());
 		$this->getStorage()->set('recorder', (int) $this->isSessionRecorderEnabled());
+		$this->getStorage()->set('learning_progress', $this->isLearningProgressEnabled());
 
 	}
 
@@ -271,6 +283,7 @@ class ilViteroSettings
 		$this->enablePhoneDialOutParticipants($this->getStorage()->get('phone_dial_out_participants', $this->isPhoneDialOutParticipantsEnabled()));
 		$this->enableMobileAccess($this->getStorage()->get('mobile',$this->isMobileAccessEnabled()));
 		$this->enableSessionRecorder($this->getStorage()->get('recorder',$this->isSessionRecorderEnabled()));
+		$this->enableLearningProgress($this->getStorage()->get('learning_progress', $this->isLearningProgressEnabled()));
 	}
 
 	/**

--- a/classes/class.ilViteroStatisticSoapConnector.php
+++ b/classes/class.ilViteroStatisticSoapConnector.php
@@ -57,7 +57,7 @@ class ilViteroStatisticSoapConnector extends ilViteroSoapConnector
 
 	}
 
-	public function getSessionAndUserRecordingsByTimeSlot($a_time_slot_start, $a_time_slot_end, $a_customer_id = 0)
+	public function getSessionAndUserRecordingsByTimeSlot($a_time_slot_start, $a_time_slot_end, $a_customer_id = 0, $a_vgroup_id= 0)
 	{
 		try {
 			$this->initClient();
@@ -67,6 +67,7 @@ class ilViteroStatisticSoapConnector extends ilViteroSoapConnector
 			$request->timeslotstart = $a_time_slot_start;
 			$request->timeslotend = $a_time_slot_end;
 			$request->customerid = $a_customer_id;
+			$request->groupid = $a_vgroup_id;
 
 			$recording_data = $this->getClient()->getSessionAndUserRecordingsByTimeSlot($request);
 

--- a/classes/class.ilViteroStatisticSoapConnector.php
+++ b/classes/class.ilViteroStatisticSoapConnector.php
@@ -29,20 +29,7 @@ class ilViteroStatisticSoapConnector extends ilViteroSoapConnector
 		}
 	}
 
-	public function getUserRecordingById()
-	{
-
-	}
-
-	public function getSessionAndUserRecordingsBySessionId()
-	{
-
-	}
-
 	/**
-	 * REQUEST required: timeslotstart, timeslotend
-	 * REQUEST optional for admins: custmoerid
-	 * REQUEST optional: groupid, bookingid, bookinngtimeid, userid, sessionsortorder, timezone
 	 * Gets information about session recordings in a specific time slot.
 	 * @param $a_time_slot_start
 	 * @param $a_time_slot_end
@@ -94,21 +81,31 @@ class ilViteroStatisticSoapConnector extends ilViteroSoapConnector
 		}
 	}
 
-	public function getCapacityRecordingByDate()
-	{
-
-	}
-
-	public function getCapacityRecordingsByTimeSlot()
-	{
-
-	}
-
 	protected function getWsdlName()
 	{
 		return self::WSDL_NAME;
 	}
 
+
+	public function getUserRecordingById()
+	{
+		//Not necessary to implement so far.
+	}
+
+	public function getSessionAndUserRecordingsBySessionId()
+	{
+		//Not necessary to implement so far.
+	}
+
+	public function getCapacityRecordingByDate()
+	{
+		//Not necessary to implement so far.
+	}
+
+	public function getCapacityRecordingsByTimeSlot()
+	{
+		//Not necessary to implement so far.
+	}
 
 }
 ?>

--- a/classes/class.ilViteroStatisticSoapConnector.php
+++ b/classes/class.ilViteroStatisticSoapConnector.php
@@ -1,0 +1,95 @@
+<?php
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * @author Jesús López <lopez@leifos.com>
+ */
+class ilViteroStatisticSoapConnector extends ilViteroSoapConnector
+{
+	const WSDL_NAME = 'statistic.wsdl';
+
+	public function getSessionRecordingById($a_session_recording_id, $a_timezone = "")
+	{
+		try {
+			$this->initClient();
+
+			$session = new stdClass();
+			$session->sessionrecordingid = $a_session_recording_id;
+			$session_recording = $this->getClient()->getSessionRecordingById($session);
+
+			return $session_recording;
+
+		}
+		catch (Exception $e)
+		{
+			$code = $this->parseErrorCode($e);
+			$GLOBALS['ilLog']->write(__METHOD__.': Get session recording by id failed with message code: '.$code);
+			$GLOBALS['ilLog']->write(__METHOD__.': Last request: '.$this->getClient()->__getLastRequest());
+			throw new ilViteroConnectorException($e->getMessage(),$code);
+		}
+	}
+
+	public function getUserRecordingById()
+	{
+
+	}
+
+	public function getSessionAndUserRecordingsBySessionId()
+	{
+
+	}
+
+	/**
+	 * REQUEST required: timeslotstart, timeslotend
+	 * REQUEST optional for admins: custmoerid
+	 * REQUEST optional: groupid, bookingid, bookinngtimeid, userid, sessionsortorder, timezone
+	 * Gets information about session recordings in a specific time slot.
+	 * @param $a_time_slot_start
+	 * @param $a_time_slot_end
+	 * @throws ilViteroConnectorException
+	 */
+	public function getSessionRecordingsByTimeSlot($a_time_slot_start, $a_time_slot_end)
+	{
+		try {
+			$this->initClient();
+
+			$session = new stdClass();
+			$session->timeslotstart = $a_time_slot_start;
+			$session->timeslotend = $a_time_slot_end;
+			$session_recording = $this->getClient()->getSessionRecordingsByTimeSlot($session);
+
+			return $session_recording;
+		}
+		catch(Exception $e)
+		{
+			$code = $this->parseErrorCode($e);
+			$GLOBALS['ilLog']->write(__METHOD__.': Get session recordings by timeslot failed with message code: '.$code);
+			$GLOBALS['ilLog']->write(__METHOD__.': Last request: '.$this->getClient()->__getLastRequest());
+			throw new ilViteroConnectorException($e->getMessage(),$code);
+		}
+
+	}
+
+	public function getSessionAndUserRecordingsByTimeSlot()
+	{
+
+	}
+
+	public function getCapacityRecordingByDate()
+	{
+
+	}
+
+	public function getCapacityRecordingsByTimeSlot()
+	{
+
+	}
+
+	protected function getWsdlName()
+	{
+		return self::WSDL_NAME;
+	}
+
+
+}
+?>

--- a/classes/class.ilViteroStatisticSoapConnector.php
+++ b/classes/class.ilViteroStatisticSoapConnector.php
@@ -53,10 +53,10 @@ class ilViteroStatisticSoapConnector extends ilViteroSoapConnector
 		try {
 			$this->initClient();
 
-			$session = new stdClass();
-			$session->timeslotstart = $a_time_slot_start;
-			$session->timeslotend = $a_time_slot_end;
-			$session_recording = $this->getClient()->getSessionRecordingsByTimeSlot($session);
+			$request = new stdClass();
+			$request->timeslotstart = $a_time_slot_start;
+			$request->timeslotend = $a_time_slot_end;
+			$session_recording = $this->getClient()->getSessionRecordingsByTimeSlot($request);
 
 			return $session_recording;
 		}
@@ -70,9 +70,28 @@ class ilViteroStatisticSoapConnector extends ilViteroSoapConnector
 
 	}
 
-	public function getSessionAndUserRecordingsByTimeSlot()
+	public function getSessionAndUserRecordingsByTimeSlot($a_time_slot_start, $a_time_slot_end, $a_customer_id = 0)
 	{
+		try {
+			$this->initClient();
 
+			$request = new stdClass();
+
+			$request->timeslotstart = $a_time_slot_start;
+			$request->timeslotend = $a_time_slot_end;
+			$request->customerid = $a_customer_id;
+
+			$recording_data = $this->getClient()->getSessionAndUserRecordingsByTimeSlot($request);
+
+			return $recording_data;
+		}
+		catch(Exception $e)
+		{
+			$code = $this->parseErrorCode($e);
+			$GLOBALS['ilLog']->write(__METHOD__.': Get session recordings by timeslot failed with message code: '.$code);
+			$GLOBALS['ilLog']->write(__METHOD__.': Last request: '.$this->getClient()->__getLastRequest());
+			throw new ilViteroConnectorException($e->getMessage(),$code);
+		}
 	}
 
 	public function getCapacityRecordingByDate()

--- a/classes/class.ilViteroUserMapping.php
+++ b/classes/class.ilViteroUserMapping.php
@@ -76,6 +76,12 @@ class ilViteroUserMapping
 		return 0;
 	}
 
+	/**
+	 * Get ILIAS user id from db mapping using a vitero user id
+	 * @param $a_user_id
+	 * @return int
+	 * @throws ilDatabaseException
+	 */
 	public function getIUserId($a_user_id)
 	{
 		global $ilDB;

--- a/classes/class.ilViteroUserMapping.php
+++ b/classes/class.ilViteroUserMapping.php
@@ -76,5 +76,19 @@ class ilViteroUserMapping
 		return 0;
 	}
 
+	public function getIUserId($a_user_id)
+	{
+		global $ilDB;
+
+		$query = 'SELECT * FROM rep_robj_xvit_umap '.
+			'WHERE vuid = '.$ilDB->quote($a_user_id,'integer');
+		$res = $ilDB->query($query);
+		while($row = $res->fetchRow(DB_FETCHMODE_OBJECT))
+		{
+			return $row->iuid;
+		}
+		return 0;
+	}
+
 }
 ?>

--- a/classes/class.ilViteroUtils.php
+++ b/classes/class.ilViteroUtils.php
@@ -137,7 +137,9 @@ class ilViteroUtils
 						$next_booking['open']->increment(ilDateTime::MINUTE, $buffer_start * -1);
 
 						$next_booking['end'] = clone $next_booking['start'];
-						$next_booking['end']->setDate($next_booking->get(IL_CAL_UNIX) + $duration,IL_CAL_UNIX);
+						//Fix to Call to a member function get() on array TODO: remove this comments
+						//$next_booking['end']->setDate($next_booking->get(IL_CAL_UNIX) + $duration,IL_CAL_UNIX);
+						$next_booking['end']->setDate($next_booking['end']->get(IL_CAL_UNIX) + $duration,IL_CAL_UNIX);
 
 						$next_booking['closed'] = clone $next_booking['end'];
 						$next_booking['closed']->increment(ilDateTime::MINUTE, $buffer_end);

--- a/classes/class.ilViteroUtils.php
+++ b/classes/class.ilViteroUtils.php
@@ -18,7 +18,7 @@ class ilViteroUtils
 
 	/**
 	 * Parse date string from soap
-	 * @param <type> $a_datetime
+	 * @param string $a_datetime
 	 * @return ilDateTime 
 	 */
 	public static function parseSoapDate($a_datetime)

--- a/classes/class.ilViteroUtils.php
+++ b/classes/class.ilViteroUtils.php
@@ -251,5 +251,22 @@ class ilViteroUtils
 		}
 		return $available_rooms;
 	}
+
+	/** Checks if the customer has Monitor Mode */
+	public static function hasCustomerMonitoringMode()
+	{
+		$licence_connector = new ilViteroLicenceSoapConnector();
+
+		$modules = $licence_connector->getModulesForCustomer(ilViteroSettings::getInstance()->getCustomer());
+
+		foreach($modules->modules->module as $module)
+		{
+			if($module->type == "MONITORING"){
+				return true;
+			}
+		}
+
+		return false;
+	}
 }
 ?>

--- a/classes/class.ilViteroUtils.php
+++ b/classes/class.ilViteroUtils.php
@@ -137,8 +137,6 @@ class ilViteroUtils
 						$next_booking['open']->increment(ilDateTime::MINUTE, $buffer_start * -1);
 
 						$next_booking['end'] = clone $next_booking['start'];
-						//Fix to Call to a member function get() on array TODO: remove this comments
-						//$next_booking['end']->setDate($next_booking->get(IL_CAL_UNIX) + $duration,IL_CAL_UNIX);
 						$next_booking['end']->setDate($next_booking['end']->get(IL_CAL_UNIX) + $duration,IL_CAL_UNIX);
 
 						$next_booking['closed'] = clone $next_booking['end'];

--- a/classes/class.ilViteroUtils.php
+++ b/classes/class.ilViteroUtils.php
@@ -270,5 +270,51 @@ class ilViteroUtils
 
 		return false;
 	}
+
+	/**
+	 * Get the date of the last vitero synchronization.
+	 * @return int
+	 * @throws ilDatabaseException
+	 */
+	public static function getLastSyncDate()
+	{
+		global $DIC;
+
+		$db = $DIC->database();
+
+		$query = 'SELECT last_sync FROM rep_robj_xvit_date';
+
+		$res = $db->query($query);
+
+		while($row = $res->fetchRow(DB_FETCHMODE_OBJECT))
+		{
+			return $row->last_sync;
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Insert/Update the last vitero synchronization.
+	 * @return int|void
+	 * @throws ilDatabaseException
+	 */
+	public static function updateLastSyncDate()
+	{
+		global $DIC;
+
+		$db = $DIC->database();
+
+		if(self::getLastSyncDate() > 0)
+		{
+			$query = "UPDATE rep_robj_xvit_date SET last_sync = " . $db->quote(time(),"integer");
+
+			return $db->manipulate($query);
+		}
+
+		$query = "INSERT INTO rep_robj_xvit_date (last_sync) VALUES(" . $db->quote(time(), "integer") . ")";
+
+		return $db->manipulate($query);
+	}
 }
 ?>

--- a/dev_notes.txt
+++ b/dev_notes.txt
@@ -1,0 +1,15 @@
+Comments about development
+---------------------------
+
+1 - Booking id issue in getSessionAndUserRecordingsByTimeSlot
+
+Method getSessionAndUserRecordingsByTimeSlot from vitero returns bookingid value.
+This bookingid id, is in fact, a booking time id. They did not change the "bookingid" name to keep back compatibility.
+
+To obtain a booking object from  this booking time id we use the method getBookingByBookingTimeId($bookingTimeId);
+
+3- Percentage round issue
+
+After doing the maths with the attendance percentage we can obtain decimal values like for example 74.6666%
+The current values are stored discriminating the decimals. For this example the stored value is 74%
+

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -157,3 +157,13 @@ settings_phone_dial_out#:#Dial Out
 settings_phone_dial_out_info#:#Participants can be called back.
 settings_phone_dial_out_part#:#Invite Participants (using a phone)
 settings_phone_dial_out_part_info#:#If enabled, participants - using a phone - can be added.
+edit_learning_progress_properties#:#Learning Progress settings
+activate_learning_progress#:#Activate Learning Progress
+activate_learning_progress_info#:#Vitero sessions will have Learning Progress configuration.
+min_percentage#:#Minimum percentage
+min_percentage_info#:#Minimum attended time to set the session "passed";
+mode#:#Mode
+one_session#:#One session
+multi_session#:#Multipe sessions
+min_sessions#:#Minimum sessions
+min_sessions_info#:#Minimum number of sessions which have to be attended the established minimum percent.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -163,10 +163,13 @@ activate_learning_progress_info#:#Vitero sessions will have Learning Progress co
 min_percentage#:#Minimum percentage
 min_percentage_info#:#Minimum attended time to set the session "passed";
 mode#:#Mode
-one_session#:#One session
-multi_session#:#Multipe sessions
-min_sessions#:#Minimum sessions
+one_session#:#One Session
+multi_session#:#Multipe Sessions
+min_sessions#:#Minimum Sessions
 min_sessions_info#:#Minimum number of sessions which have to be attended the established minimum percent.
 currently_multi_appointments#:#This session has multiple appointments.
 currently_one_appointment#:#This session has only one appointment.
 learning_progress#:#Learning Progress
+delete_info_minimum_app#:#Minimum 2 appointments are required due to Learning Progress configuration.
+delete_info_disable_lp#:#Minimum 1 appointment is required due to Learning Progress configuration.
+add_appointment_disabled_info#:#No more appointments can be created due to Learning Progress configuration.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -167,3 +167,5 @@ one_session#:#One session
 multi_session#:#Multipe sessions
 min_sessions#:#Minimum sessions
 min_sessions_info#:#Minimum number of sessions which have to be attended the established minimum percent.
+currently_multi_appointments#:#This session has multiple appointments.
+currently_one_appointment#:#This session has only one appointment.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -169,3 +169,4 @@ min_sessions#:#Minimum sessions
 min_sessions_info#:#Minimum number of sessions which have to be attended the established minimum percent.
 currently_multi_appointments#:#This session has multiple appointments.
 currently_one_appointment#:#This session has only one appointment.
+learning_progress#:#Learning Progress

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -173,3 +173,6 @@ learning_progress#:#Learning Progress
 delete_info_minimum_app#:#Minimum 2 appointments are required due to Learning Progress configuration.
 delete_info_disable_lp#:#Minimum 1 appointment is required due to Learning Progress configuration.
 add_appointment_disabled_info#:#No more appointments can be created due to Learning Progress configuration.
+btn_sync_lp_info#:#Synchronize all vitero sessions
+btn_sync_lp#:#Synchronize
+info_msg_session_sinc_success#:#Vitero session synchronized successfully

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
 $id = "xvit";
  
 // code version; must be changed for all code changes
-$version = "5.3.2.16";
+$version = "5.3.2.17";
  
 // ilias min and max version; must always reflect the versions that should
 // run with the plugin

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
 $id = "xvit";
  
 // code version; must be changed for all code changes
-$version = "5.3.2.18";
+$version = "5.3.2.19";
  
 // ilias min and max version; must always reflect the versions that should
 // run with the plugin

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
 $id = "xvit";
  
 // code version; must be changed for all code changes
-$version = "5.3.2.17";
+$version = "5.3.2.18";
  
 // ilias min and max version; must always reflect the versions that should
 // run with the plugin

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
 $id = "xvit";
  
 // code version; must be changed for all code changes
-$version = "5.3.2.14";
+$version = "5.3.2.15";
  
 // ilias min and max version; must always reflect the versions that should
 // run with the plugin
@@ -14,4 +14,7 @@ $ilias_max_version = "5.3.999";
 // optional, but useful: Add one or more responsible persons and a contact email
 $responsible = "Stefan Meyer";
 $responsible_mail = "meyer@leifos.com";
+
+// support for learning progress
+$learning_progress = true;
 ?>

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
 $id = "xvit";
  
 // code version; must be changed for all code changes
-$version = "5.3.2.15";
+$version = "5.3.2.16";
  
 // ilias min and max version; must always reflect the versions that should
 // run with the plugin

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
 $id = "xvit";
  
 // code version; must be changed for all code changes
-$version = "5.3.2.19";
+$version = "5.3.2.20";
  
 // ilias min and max version; must always reflect the versions that should
 // run with the plugin

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -352,5 +352,15 @@ if(!$ilDB->tableExists('rep_robj_xvit_recs'))
 	$ilDB->addPrimaryKey('rep_robj_xvit_recs',array('user_id','obj_id','recording_id'));
 }
 ?>
+<#15>
+<?php
+if($ilDB->tableExists('rep_robj_xvit_recs'))
+{
+	if($ilDB->tableColumnExists('rep_robj_xvit_recs','percent'))
+	{
+		$ilDB->renameTableColumn('rep_robj_xvit_recs','percent', 'percentage');
+	}
+}
+?>
 
 

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -265,4 +265,26 @@ if(!$ilDB->tableExists('rep_robj_xvit_webcodes'))
 }
 $ilDB->addPrimaryKey('rep_robj_xvit_webcodes',array('vgroup_id','booking_id'));
 ?>
+<#12>
+<?php
+include_once('./Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php');
+$edit_operation_id = ilDBUpdateNewObjectType::getCustomRBACOperationId("edit_learning_progress");
+$write_operation_id = ilDBUpdateNewObjectType::getCustomRBACOperationId('write');
+
+if($edit_operation_id)
+{
+	$lp_types = array("xvit");
+
+	foreach($lp_types as $lp_type)
+	{
+		$lp_type_id = ilDBUpdateNewObjectType::getObjectTypeId($lp_type);
+
+		if($lp_type_id)
+		{
+			ilDBUpdateNewObjectType::addRBACOperation($lp_type_id, $edit_operation_id);
+			ilDBUpdateNewObjectType::cloneOperation($lp_type, $write_operation_id, $edit_operation_id);
+		}
+	}
+}
+?>
 

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -322,5 +322,35 @@ if(!$ilDB->tableExists('rep_robj_xvit_lp'))
 }
 $ilDB->addPrimaryKey('rep_robj_xvit_lp',array('obj_id'));
 ?>
+<#14>
+<?php
+if(!$ilDB->tableExists('rep_robj_xvit_recs'))
+{
+	$ilDB->createTable('rep_robj_xvit_recs', array(
+		'user_id'	=> array(
+			'type'	=> 'integer',
+			'length'=> 4,
+			'notnull' => TRUE
+		),
+		'obj_id'	=> array(
+			'type'	=> 'integer',
+			'length'=> 4,
+			'notnull' => TRUE
+		),
+		'recording_id'	=> array(
+			'type'	=> 'integer',
+			'length'=> 4,
+			'notnull' => TRUE
+		),
+		'percent'	=> array(
+			'type'	=> 'integer',
+			'length'=> 4,
+			'notnull' => TRUE
+		)
+	));
+
+	$ilDB->addPrimaryKey('rep_robj_xvit_recs',array('user_id','obj_id','recording_id'));
+}
+?>
 
 

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -287,4 +287,40 @@ if($edit_operation_id)
 	}
 }
 ?>
+<#13>
+<?php
+if(!$ilDB->tableExists('rep_robj_xvit_lp'))
+{
+	$ilDB->createTable('rep_robj_xvit_lp',array(
+		'obj_id'	=> array(
+			'type'	=> 'integer',
+			'length'=> 4,
+			'notnull' => TRUE
+		),
+		'active'	=> array(
+			'type'	=> 'integer',
+			'length'=> 4,
+			'notnull' => FALSE
+		),
+		'min_percent'	=> array(
+			'type'	=> 'integer',
+			'length' => 4,
+			'notnull' => FALSE,
+		),
+		'mode_multi'	=> array(
+			'type'	=> 'integer',
+			'length' => 4,
+			'notnull' => FALSE,
+		),
+		'min_sessions'	=> array(
+			'type'	=> 'integer',
+			'length' => 4,
+			'notnull' => FALSE,
+		),
+
+	));
+}
+$ilDB->addPrimaryKey('rep_robj_xvit_lp',array('obj_id'));
+?>
+
 

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -362,5 +362,18 @@ if($ilDB->tableExists('rep_robj_xvit_recs'))
 	}
 }
 ?>
+<#16>
+<?php
+if(!$ilDB->tableExists("rep_robj_xvit_date"))
+{
+	$ilDB->createTable('rep_robj_xvit_date', array(
+		'last_sync'	=> array(
+			'type'	=> 'integer',
+			'length'=> 4,
+			'notnull' => TRUE
+		)
+	));
+}
+?>
 
 


### PR DESCRIPTION
Draft to follow the development status.
The goal is to implement Learning Progress for vitero sessions.
Todo list:

- [x] Nice to have: Button to refresh the learning progress inside the session->learning progress tab. (Implemented in the settings tab)
- [ ] Delete the vitero team from vitero platform, when the vitero session (repo obj) in ILIAS is deleted.
- [x] Set tabs and redirect properly when saving the vitero obj settings.
- [ ] Check if the client SOAP API has the statistic module. Hide all Learning Progress stuff if the module is not available.
- [x] Refactor and remove all TODO comments
- [ ] Add german language
- [x] Show also past appointments in the appointments table when the user is admin of the session.
- [x] All the implementation must be migrated to ILIAS release 5.4
- [x] Cron job plugin to consume the vitero statistics and store the calculations in the ILIAS DB.
- [x] Implement methods in ilObjVitero to follow the contract with ilLPStatusPluginInterface

